### PR TITLE
Fix season not loading after logging ten placement matches

### DIFF
--- a/app/helpers/matches_helper.rb
+++ b/app/helpers/matches_helper.rb
@@ -188,8 +188,12 @@ module MatchesHelper
 
   def match_rank_change(match, matches)
     return '--' if match.placement?
-    return '' unless match.prior_match
-    match.rank - match.prior_match.rank
+
+    prior_match = match.prior_match
+    return '' unless prior_match
+    return '--' if prior_match.placement?
+
+    match.rank - prior_match.rank
   end
 
   def match_rank_change_style(match, matches)

--- a/app/javascript/packs/match-time.js
+++ b/app/javascript/packs/match-time.js
@@ -1,7 +1,11 @@
 import {on} from 'delegated-events'
 
-on('click', '.js-log-match-tab', function() {
+function selectTimeAndDay() {
   const timeSelect = document.getElementById('match_time_of_day')
+  if (!timeSelect) {
+    return
+  }
+
   const daySelect = document.getElementById('match_day_of_week')
   const date = new Date()
   const dayOfWeek = date.getDay()
@@ -23,4 +27,7 @@ on('click', '.js-log-match-tab', function() {
   } else {
     timeSelect.value = 'night'
   }
-})
+}
+
+on('click', '.js-log-match-tab', selectTimeAndDay)
+selectTimeAndDay()

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,13 +46,8 @@ class User < ApplicationRecord
   end
 
   def friend_names(season)
-    season_matches = matches.in_season(season).includes(:friends)
-    if season_matches.empty?
-      all_friend_names
-    else
-      season_matches.flat_map(&:friends).uniq.
-        sort_by { |friend| friend.name.downcase }.map(&:name)
-    end
+    matches.in_season(season).includes(:friends).flat_map(&:friends).uniq.
+      sort_by { |friend| friend.name.downcase }.map(&:name)
   end
 
   def all_friend_names

--- a/app/views/matches/_placement_form.html.erb
+++ b/app/views/matches/_placement_form.html.erb
@@ -32,18 +32,12 @@
       <%= render partial: 'matches/time_field', locals: { form: form, match: match } %>
       <%= render partial: 'matches/day_field', locals: { form: form, match: match } %>
     </div>
+    <%= render partial: 'matches/friends',
+               locals: { form: form, match: match, friends: friends, all_friends: all_friends } %>
+    <%= render partial: 'matches/thrower_leaver_fields', locals: { form: form } %>
     <%= render partial: 'matches/comment_field', locals: { form: form } %>
   </div>
   <div class="col-md-12 col-lg-6 float-left">
     <%= render partial: 'matches/hero_options', locals: { heroes_by_role: heroes_by_role, match: match } %>
-  </div>
-</div>
-<div class="clearfix">
-  <div class="col-md-12 col-lg-6 float-left pr-4">
-    <%= render partial: 'matches/friends',
-               locals: { form: form, match: match, friends: friends, all_friends: all_friends } %>
-  </div>
-  <div class="col-md-12 col-lg-6 float-left">
-    <%= render partial: 'matches/thrower_leaver_fields', locals: { form: form } %>
   </div>
 </div>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,7 +49,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :warn
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]

--- a/test/controllers/season_shares_controller_test.rb
+++ b/test/controllers/season_shares_controller_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class SeasonSharesControllerTest < ActionDispatch::IntegrationTest
+  fixtures :seasons
+
   test 'can view your own shares' do
     user = create(:user)
     oauth_account1 = create(:oauth_account, user: user)

--- a/test/controllers/stats_controller_test.rb
+++ b/test/controllers/stats_controller_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class StatsControllerTest < ActionDispatch::IntegrationTest
+  fixtures :seasons
+
   setup do
     @oauth_account = create(:oauth_account)
   end

--- a/test/helpers/matches_helper_test.rb
+++ b/test/helpers/matches_helper_test.rb
@@ -1,0 +1,13 @@
+class MatchesHelperTest < ActionView::TestCase
+  test "does not calculate rank change from penultimate to last placement match" do
+    oauth_account = create(:oauth_account)
+    penultimate_match = create(:match, oauth_account: oauth_account, result: :win,
+                               placement: true, rank: nil)
+    last_placement_match = create(:match, oauth_account: oauth_account, rank: 2540,
+                                  prior_match: penultimate_match)
+
+    actual = match_rank_change(last_placement_match, [penultimate_match, last_placement_match])
+
+    assert_equal '--', actual
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -109,13 +109,13 @@ class UserTest < ActiveSupport::TestCase
     refute OauthAccount.exists?(oauth_account2.id)
   end
 
-  test "friend_names returns all user's friends when season has no matches" do
+  test "friend_names returns empty list when season has no matches" do
     user = create(:user)
     friend1 = create(:friend, user: user, name: 'Tamara')
     friend2 = create(:friend, user: user, name: 'Marcus')
     friend3 = create(:friend, user: user, name: 'Phillipe')
 
-    assert_equal %w[Marcus Phillipe Tamara], user.friend_names(3)
+    assert_empty user.friend_names(3)
   end
 
   test 'friend_names returns unique, sorted list of names from friends in matches that season' do


### PR DESCRIPTION
This should fix #23.

✨ Bonus: ✨ 

- The 'day of week' and 'time of day' menus now get auto-populated based on your current time in the 'Log a placement match' form.
- When you start a new season, you won't see checkboxes for every person you've ever grouped with. Instead, you'll just have the free-form text field which will autocomplete your friends' names as you type.
- The placement match form is a bit more compact.