### PR TITLE
Add some admin tools for linking accounts, merging users

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -2,14 +2,21 @@ class AdminController < ApplicationController
   before_action :require_admin
 
   def index
-    @users = User.order_by_battletag.paginate(page: current_page)
+    all_users = User.order_by_battletag
+    @users = all_users.paginate(page: current_page)
     @oauth_accounts_by_user_id = OauthAccount.order_by_battletag.group_by(&:user_id)
     @seasons = Season.latest_first.select(:number)
     @matches_by_oauth_account_id = Match.select([:season, :oauth_account_id]).
       group_by(&:oauth_account_id)
+    @user_options = [['--', '']] + all_users.map { |user| [user.battletag, user.id] }
   end
 
   def link_accounts
+    unless params[:primary_user_id] && params[:secondary_user_id]
+      flash[:error] = 'Please choose a primary and a secondary user.'
+      return redirect_to(admin_path)
+    end
+
     secondary_user = User.find(params[:secondary_user_id])
     primary_user = User.find(params[:primary_user_id])
 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -12,6 +12,26 @@ class AdminController < ApplicationController
     @userless_accounts = OauthAccount.without_user.order_by_battletag
   end
 
+  def update_account
+    unless params[:user_id] && params[:oauth_account_id]
+      flash[:error] = 'Please specify a user and an account.'
+      return redirect_to(admin_path)
+    end
+
+    user = User.find(params[:user_id])
+    oauth_account = OauthAccount.find(params[:oauth_account_id])
+    oauth_account.user = user
+
+    if oauth_account.save
+      flash[:notice] = "Successfully tied account #{oauth_account} to user #{user}."
+    else
+      flash[:error] = "Could not tie account #{oauth_account} to user #{user}: " +
+                      oauth_account.errors.full_messages.join(', ')
+    end
+
+    redirect_to admin_path
+  end
+
   def merge_users
     unless params[:primary_user_id] && params[:secondary_user_id]
       flash[:error] = 'Please choose a primary and a secondary user.'

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -9,6 +9,7 @@ class AdminController < ApplicationController
     @matches_by_oauth_account_id = Match.select([:season, :oauth_account_id]).
       group_by(&:oauth_account_id)
     @user_options = [['--', '']] + all_users.map { |user| [user.battletag, user.id] }
+    @userless_accounts = OauthAccount.without_user.order_by_battletag
   end
 
   def link_accounts

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -10,6 +10,8 @@ class AdminController < ApplicationController
       group_by(&:oauth_account_id)
     @user_options = [['--', '']] + all_users.map { |user| [user.battletag, user.id] }
     @userless_accounts = OauthAccount.without_user.order_by_battletag
+    @userless_account_options = [['--', '']] +
+      @userless_accounts.map { |oauth_account| [oauth_account.battletag, oauth_account.id] }
   end
 
   def update_account

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -12,7 +12,7 @@ class AdminController < ApplicationController
     @userless_accounts = OauthAccount.without_user.order_by_battletag
   end
 
-  def link_accounts
+  def merge_users
     unless params[:primary_user_id] && params[:secondary_user_id]
       flash[:error] = 'Please choose a primary and a secondary user.'
       return redirect_to(admin_path)

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -8,4 +8,17 @@ class AdminController < ApplicationController
     @matches_by_oauth_account_id = Match.select([:season, :oauth_account_id]).
       group_by(&:oauth_account_id)
   end
+
+  def link_accounts
+    secondary_user = User.find(params[:secondary_user_id])
+    primary_user = User.find(params[:primary_user_id])
+
+    if secondary_user.merge_with(primary_user)
+      flash[:notice] = "Successfully linked #{secondary_user} with #{primary_user}."
+    else
+      flash[:error] = "Failed to link #{secondary_user} with #{primary_user}."
+    end
+
+    redirect_to admin_path
+  end
 end

--- a/app/models/oauth_account.rb
+++ b/app/models/oauth_account.rb
@@ -6,6 +6,7 @@ class OauthAccount < ApplicationRecord
   validates :uid, presence: true, uniqueness: { scope: :provider }
 
   scope :order_by_battletag, ->{ order('LOWER(battletag) ASC') }
+  scope :without_user, ->{ where(user_id: nil) }
 
   after_update :remove_default, if: :saved_change_to_user_id?
 

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -64,7 +64,7 @@
 
 <div class="border border-red p-3 mt-4 col-md-6 rounded-2">
   <h2 class="h2">Merge users</h2>
-  <%= form_tag admin_link_accounts_path do %>
+  <%= form_tag admin_merge_users_path do %>
     <div class="form-group">
       <label for="primary_user_id">Primary user:</label>
       <%= select_tag :primary_user_id, options_for_select(@user_options), class: 'form-select', required: true %>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -62,25 +62,48 @@
 
 <hr class="py-4">
 
-<div class="border border-red p-3 mt-4 col-md-6 rounded-2">
-  <h2 class="h2">Merge users</h2>
-  <%= form_tag admin_merge_users_path do %>
-    <div class="form-group">
-      <label for="primary_user_id">Primary user:</label>
-      <%= select_tag :primary_user_id, options_for_select(@user_options), class: 'form-select', required: true %>
-      <p class="note">
-        This user will be kept.
-      </p>
+<div class="mt-4 clearfix">
+  <% if @users.size > 1 %>
+    <div class="border border-red p-3 col-md-6 rounded-2">
+      <h2 class="h2">Merge users</h2>
+      <%= form_tag admin_merge_users_path do %>
+        <div class="form-group">
+          <label for="primary_user_id">Primary user:</label>
+          <%= select_tag :primary_user_id, options_for_select(@user_options), class: 'form-select', required: true %>
+          <p class="note">
+            This user will be kept.
+          </p>
+        </div>
+        <div class="form-group">
+          <label for="secondary_user_id">Secondary user:</label>
+          <%= select_tag :secondary_user_id, options_for_select(@user_options), class: 'form-select', required: true %>
+          <p class="note">
+            This user will be deleted.
+          </p>
+        </div>
+        <button type="submit" class="btn btn-danger" data-confirm="Are you sure you want to combine these users?">
+          Combine users
+        </button>
+      <% end %>
     </div>
-    <div class="form-group">
-      <label for="secondary_user_id">Secondary user:</label>
-      <%= select_tag :secondary_user_id, options_for_select(@user_options), class: 'form-select', required: true %>
-      <p class="note">
-        This user will be deleted.
-      </p>
+  <% end %>
+
+  <% if @userless_accounts.any? %>
+    <div class="border border-red p-3 col-md-6 rounded-2">
+      <h2 class="h2">Tie account to a user</h2>
+      <%= form_tag admin_update_account_path do %>
+        <div class="form-group">
+          <label for="user_id">User:</label>
+          <%= select_tag :user_id, options_for_select(@user_options), class: 'form-select', required: true %>
+        </div>
+        <div class="form-group">
+          <label for="oauth_account_id">Account:</label>
+          <%= select_tag :oauth_account_id, options_for_select(@userless_account_options), class: 'form-select', required: true %>
+        </div>
+        <button type="submit" class="btn btn-danger" data-confirm="Are you sure you want to connect the account to the user?">
+          Connect account to user
+        </button>
+      <% end %>
     </div>
-    <button type="submit" class="btn btn-danger" data-confirm="Are you sure you want to combine these users?">
-      Combine users
-    </button>
   <% end %>
 </div>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -4,7 +4,7 @@
   Users
   <span class="text-normal text-gray h3">(<%= @users.total_entries %>)</span>
 </h2>
-<ul class="list-style-none">
+<ul class="list-style-none mb-4">
   <% @users.each_with_index do |user, i| %>
     <li class="<%= 'border-top mt-2 pt-2' if i > 0 %>">
       <h3 class="h4"><%= user %></h3>
@@ -43,8 +43,33 @@
 </ul>
 
 <% if @users.total_pages > 1 %>
-  <div class="mt-4">
+  <div class="my-4">
     <%= page_entries_info @users %>
     <%= will_paginate @users, page_links: false %>
   </div>
 <% end %>
+
+<hr class="py-4">
+
+<div class="border border-red p-3 mt-4 col-md-6 rounded-2">
+  <h2 class="h2">Merge users</h2>
+  <%= form_tag admin_link_accounts_path do %>
+    <div class="form-group">
+      <label for="primary_user_id">Primary user:</label>
+      <%= select_tag :primary_user_id, options_for_select(@user_options), class: 'form-select', required: true %>
+      <p class="note">
+        This user will be kept.
+      </p>
+    </div>
+    <div class="form-group">
+      <label for="secondary_user_id">Secondary user:</label>
+      <%= select_tag :secondary_user_id, options_for_select(@user_options), class: 'form-select', required: true %>
+      <p class="note">
+        This user will be deleted.
+      </p>
+    </div>
+    <button type="submit" class="btn btn-danger" data-confirm="Are you sure you want to combine these users?">
+      Combine users
+    </button>
+  <% end %>
+</div>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -49,6 +49,17 @@
   </div>
 <% end %>
 
+<% if @userless_accounts.any? %>
+  <hr>
+
+  <h2 class="h2">Accounts without users</h2>
+  <ul class="list-style-none">
+    <% @userless_accounts.each do |oauth_account| %>
+      <li><%= oauth_account %></li>
+    <% end %>
+  </ul>
+<% end %>
+
 <hr class="py-4">
 
 <div class="border border-red p-3 mt-4 col-md-6 rounded-2">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
 
   get '/admin' => 'admin#index', as: :admin
   post '/admin/merge-users' => 'admin#merge_users', as: :admin_merge_users
+  post '/admin/update-account' => 'admin#update_account', as: :admin_update_account
 
   get '/.well-known/acme-challenge/:id' => 'pages#lets_encrypt'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
   get '/stats' => 'stats#index', as: :stats
 
   get '/admin' => 'admin#index', as: :admin
+  post '/admin/link-accounts' => 'admin#link_accounts', as: :admin_link_accounts
 
   get '/.well-known/acme-challenge/:id' => 'pages#lets_encrypt'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,7 @@ Rails.application.routes.draw do
   get '/stats' => 'stats#index', as: :stats
 
   get '/admin' => 'admin#index', as: :admin
-  post '/admin/link-accounts' => 'admin#link_accounts', as: :admin_link_accounts
+  post '/admin/merge-users' => 'admin#merge_users', as: :admin_merge_users
 
   get '/.well-known/acme-challenge/:id' => 'pages#lets_encrypt'
 

--- a/test/controllers/admin_controller_test.rb
+++ b/test/controllers/admin_controller_test.rb
@@ -44,7 +44,21 @@ class AdminControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
-  test 'admin can link accounts' do
+  test 'admin gets warning if user ID is not specified when merging users' do
+    admin_user = create(:user, admin: true)
+    admin_account = create(:oauth_account, user: admin_user)
+
+    assert_no_difference 'User.count' do
+      sign_in_as(admin_account)
+      post '/admin/link-accounts', params: { primary_user_id: admin_user.id }
+    end
+
+    assert_nil flash[:notice]
+    assert_equal 'Please choose a primary and a secondary user.', flash[:error]
+    assert_redirected_to admin_path
+  end
+
+  test 'admin can merge two users' do
     primary_user = create(:user)
     secondary_user = create(:user)
     primary_account = create(:oauth_account, user: primary_user)

--- a/test/controllers/admin_controller_test.rb
+++ b/test/controllers/admin_controller_test.rb
@@ -38,7 +38,7 @@ class AdminControllerTest < ActionDispatch::IntegrationTest
 
     assert_no_difference 'User.count' do
       sign_in_as(oauth_account)
-      post '/admin/link-accounts', params: {
+      post '/admin/merge-users', params: {
         primary_user_id: primary_user.id,
         secondary_user_id: secondary_user.id
       }
@@ -53,7 +53,7 @@ class AdminControllerTest < ActionDispatch::IntegrationTest
 
     assert_no_difference 'User.count' do
       sign_in_as(admin_account)
-      post '/admin/link-accounts', params: { primary_user_id: admin_user.id }
+      post '/admin/merge-users', params: { primary_user_id: admin_user.id }
     end
 
     assert_nil flash[:notice]
@@ -71,7 +71,7 @@ class AdminControllerTest < ActionDispatch::IntegrationTest
 
     assert_difference 'User.count', -1 do
       sign_in_as(admin_account)
-      post '/admin/link-accounts', params: {
+      post '/admin/merge-users', params: {
         primary_user_id: primary_user.id,
         secondary_user_id: secondary_user.id
       }

--- a/test/controllers/admin_controller_test.rb
+++ b/test/controllers/admin_controller_test.rb
@@ -26,4 +26,45 @@ class AdminControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :ok
   end
+
+  test 'non-admin cannot link accounts' do
+    primary_user = create(:user)
+    secondary_user = create(:user)
+    user = create(:user)
+    oauth_account = create(:oauth_account, user: user)
+
+    assert_no_difference 'User.count' do
+      sign_in_as(oauth_account)
+      post '/admin/link-accounts', params: {
+        primary_user_id: primary_user.id,
+        secondary_user_id: secondary_user.id
+      }
+    end
+
+    assert_response :not_found
+  end
+
+  test 'admin can link accounts' do
+    primary_user = create(:user)
+    secondary_user = create(:user)
+    primary_account = create(:oauth_account, user: primary_user)
+    secondary_account = create(:oauth_account, user: secondary_user)
+    admin_user = create(:user, admin: true)
+    admin_account = create(:oauth_account, user: admin_user)
+
+    assert_difference 'User.count', -1 do
+      sign_in_as(admin_account)
+      post '/admin/link-accounts', params: {
+        primary_user_id: primary_user.id,
+        secondary_user_id: secondary_user.id
+      }
+    end
+
+    assert_nil flash[:error]
+    assert_equal "Successfully linked #{secondary_account} with #{primary_account}.", flash[:notice]
+    assert_redirected_to admin_path
+    refute User.exists?(secondary_user.id)
+    assert User.exists?(primary_user.id)
+    assert_equal primary_user, secondary_account.reload.user
+  end
 end

--- a/test/controllers/admin_controller_test.rb
+++ b/test/controllers/admin_controller_test.rb
@@ -20,11 +20,14 @@ class AdminControllerTest < ActionDispatch::IntegrationTest
   test 'loads successfully for admin' do
     user = create(:user, admin: true)
     oauth_account = create(:oauth_account, user: user)
+    userless_oauth_account = create(:oauth_account, user: nil)
 
     sign_in_as(oauth_account)
     get '/admin'
 
     assert_response :ok
+    assert_select 'button', text: /#{oauth_account.battletag}/
+    assert_select 'li', text: userless_oauth_account.battletag
   end
 
   test 'non-admin cannot link accounts' do

--- a/test/factories/oauth_accounts.rb
+++ b/test/factories/oauth_accounts.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     user
     provider 'bnet'
     uid { "12345#{OauthAccount.count}" }
-    battletag { user.battletag }
+    battletag { user ? user.battletag : "SomeAccount#123#{OauthAccount.count}" }
   end
 end


### PR DESCRIPTION
This adds a couple forms to the admin page:

- Merge two users, which migrates friends and accounts from one user to another user and deletes the now-empty user.
- Link an account that's not tied to a user to an existing user.