### PR TITLE
Store heroes played in matches table

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -16,8 +16,9 @@ class MatchesController < ApplicationController
   def index
     @can_edit = signed_in? && @account.user == current_user
     @matches = @account.matches.in_season(@season_number).
-      includes(:prior_match, :heroes, :map).ordered_by_time
+      includes(:prior_match, :map).ordered_by_time
     Match.prefill_group_members(@matches, user: @account.user)
+    Match.prefill_heroes(@matches)
     set_streaks(@matches)
     @longest_win_streak = @matches.map(&:win_streak).compact.max
     @longest_loss_streak = @matches.map(&:loss_streak).compact.max

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -50,11 +50,9 @@ class MatchesController < ApplicationController
     end
 
     @match.set_friends_from_names(@selected_friend_names)
+    @match.hero_ids = @selected_heroes
 
     return render_edit_on_fail unless @match.save
-
-    @match.set_heroes_from_ids(@selected_heroes)
-
     redirect_to matches_path(@season_number, @account, anchor: "match-row-#{@match.id}")
   end
 
@@ -99,11 +97,9 @@ class MatchesController < ApplicationController
     end
 
     @match.set_friends_from_names(@selected_friend_names)
+    @match.hero_ids = @selected_heroes
 
     return render_edit_on_fail unless @match.save
-
-    @match.set_heroes_from_ids(@selected_heroes)
-
     redirect_to matches_path(@match.season, @account, anchor: "match-row-#{@match.id}")
   end
 

--- a/app/controllers/seasons_controller.rb
+++ b/app/controllers/seasons_controller.rb
@@ -17,8 +17,9 @@ class SeasonsController < ApplicationController
   end
 
   def confirm_wipe
-    @matches = @account.matches.in_season(@season).includes(:heroes, :map).ordered_by_time
+    @matches = @account.matches.in_season(@season).includes(:map).ordered_by_time
     Match.prefill_group_members(@matches, user: @account.user)
+    Match.prefill_heroes(@matches)
     @match_count = @matches.count
   end
 

--- a/app/helpers/trends_helper.rb
+++ b/app/helpers/trends_helper.rb
@@ -1,4 +1,22 @@
 module TrendsHelper
+  def hero_bar(hero, match_count:, max_match_count:, total_match_count:)
+    tooltip = number_with_delimiter(match_count) + ' match'.pluralize(match_count)
+    width_percent = hero_bar_width(match_count, max_match_count, total_match_count)
+    content_tag(:div, class: 'd-flex flex-items-center mb-1 hero-list-item') do
+      safe_join([
+        image_tag("heroes/#{hero.slug}.png", alt: hero.name,
+                  class: 'flex-shrink-0 rounded-2 d-inline-block mr-2 hero-portrait',
+                  width: 30, height: 30),
+        content_tag(:span, hero, class: 'd-inline-block hero-name text-bold mr-2'),
+        content_tag(:span, 'aria-label' => tooltip,
+                    class: 'hero-bar-container tooltipped tooltipped-w d-inline-block') do
+          content_tag(:span, '', style: "width: #{width_percent}%",
+                      class: "hero-bar hero-bar-#{hero.slug} d-inline-block rounded-2")
+        end
+      ])
+    end
+  end
+
   def group_member_chart_style(group_members)
     height = group_members.size * 80
     height = 600 if height > 600

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -46,12 +46,19 @@ class Account < ApplicationRecord
   end
 
   def most_played_heroes(limit: 5)
-    matches_played_by_hero_id = MatchHero.joins(:match).where(matches: { account_id: id }).
-      group(:hero_id).count.sort_by { |_hero_id, match_count| -match_count }.to_h
+    matches_played_by_hero_id = Hash.new(0)
+    matches = Match.where(account_id: id).select(:hero_ids)
+    matches.each do |match|
+      match.hero_ids.each do |hero_id|
+        matches_played_by_hero_id[hero_id] += 1
+      end
+    end
+    matches_played_by_hero_id = matches_played_by_hero_id.
+      sort_by { |_hero_id, match_count| -match_count }.to_h
     hero_ids = matches_played_by_hero_id.keys.take(limit)
-    heroes = Hero.where(id: hero_ids).map { |hero| [hero.id, hero] }.to_h
+    heroes_by_id = Hero.where(id: hero_ids).map { |hero| [hero.id, hero] }.to_h
     hero_ids.map do |hero_id|
-      hero = heroes[hero_id]
+      hero = heroes_by_id[hero_id]
       [hero, matches_played_by_hero_id[hero_id]]
     end.to_h
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -40,7 +40,6 @@ class Account < ApplicationRecord
 
   has_many :matches, dependent: :destroy
   has_many :season_shares, dependent: :destroy
-  has_many :heroes, through: :matches
 
   def self.top_rank
     with_rank.select('MAX(rank) AS max_rank').to_a.first.max_rank

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -46,15 +46,7 @@ class Account < ApplicationRecord
   end
 
   def most_played_heroes(limit: 5)
-    matches_played_by_hero_id = Hash.new(0)
-    matches = Match.where(account_id: id).select(:hero_ids)
-    matches.each do |match|
-      match.hero_ids.each do |hero_id|
-        matches_played_by_hero_id[hero_id] += 1
-      end
-    end
-    matches_played_by_hero_id = matches_played_by_hero_id.
-      sort_by { |_hero_id, match_count| -match_count }.to_h
+    matches_played_by_hero_id = Match.count_by_hero_id(scope: Match.where(account_id: id))
     hero_ids = matches_played_by_hero_id.keys.take(limit)
     heroes_by_id = Hero.where(id: hero_ids).map { |hero| [hero.id, hero] }.to_h
     hero_ids.map do |hero_id|

--- a/app/models/hero.rb
+++ b/app/models/hero.rb
@@ -38,8 +38,7 @@ class Hero < ApplicationRecord
   end
 
   def self.most_played(limit: 5)
-    matches_played_by_hero_id = MatchHero.group(:hero_id).count.
-      sort_by { |_hero_id, match_count| -match_count }.to_h
+    matches_played_by_hero_id = Match.count_by_hero_id
     hero_ids = matches_played_by_hero_id.keys.take(limit)
     heroes = Hero.where(id: hero_ids).map { |hero| [hero.id, hero] }.to_h
     hero_ids.map do |hero_id|

--- a/app/models/hero.rb
+++ b/app/models/hero.rb
@@ -8,8 +8,6 @@ class Hero < ApplicationRecord
 
   alias_attribute :to_s, :name
 
-  has_and_belongs_to_many :matches
-
   ROLE_SORT = {
     'DPS' => 0,
     'hitscan' => 1,

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -35,7 +35,6 @@ class Match < ApplicationRecord
   validate :group_size_within_limit
 
   has_one :user, through: :account
-  has_and_belongs_to_many :heroes
 
   scope :wins, ->{ where(result: RESULT_MAPPINGS[:win]) }
   scope :losses, ->{ where(result: RESULT_MAPPINGS[:loss]) }

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -271,20 +271,6 @@ class Match < ApplicationRecord
     end
   end
 
-  def set_heroes_from_ids(hero_ids)
-    heroes_to_keep = Hero.where(id: hero_ids)
-    heroes_to_remove = heroes - heroes_to_keep
-    heroes_to_add = heroes_to_keep - heroes
-
-    heroes_to_remove.each do |hero|
-      heroes.delete(hero)
-    end
-
-    heroes_to_add.each do |hero|
-      self.heroes << hero
-    end
-  end
-
   def placement_log?
     map.blank? && persisted? && !placement? && prior_match.nil?
   end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -9,7 +9,7 @@ class Match < ApplicationRecord
   RANK_TIERS = [:bronze, :silver, :gold, :platinum, :diamond, :master, :grandmaster].freeze
 
   attr_accessor :win_streak, :loss_streak
-  attr_writer :group_members, :heroes
+  attr_writer :group_members
 
   belongs_to :account
   belongs_to :map, required: false
@@ -107,6 +107,11 @@ class Match < ApplicationRecord
 
   def heroes
     @heroes ||= Hero.where(id: hero_ids).order_by_name
+  end
+
+  def heroes=(list)
+    @heroes = list
+    self.hero_ids = list.map(&:id)
   end
 
   def self.prefill_group_members(matches, user:)

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -33,6 +33,7 @@ class Match < ApplicationRecord
   validate :account_has_not_met_season_limit
   validate :friend_user_matches_account
   validate :group_size_within_limit
+  validate :hero_ids_exist
 
   has_one :user, through: :account
 
@@ -415,6 +416,15 @@ class Match < ApplicationRecord
     old_friends = Friend.where(id: group_member_ids)
     old_friends.each do |friend|
       friend.destroy if friend.matches.empty?
+    end
+  end
+
+  def hero_ids_exist
+    return if hero_ids.empty?
+    valid_hero_ids = Hero.pluck(:id)
+    invalid_hero_ids = valid_hero_ids - hero_ids
+    if invalid_hero_ids.any?
+      errors.add(:hero_ids, "contains invalid values: #{invalid_hero_ids.map(&:to_s).join(', ')}")
     end
   end
 end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -9,7 +9,7 @@ class Match < ApplicationRecord
   RANK_TIERS = [:bronze, :silver, :gold, :platinum, :diamond, :master, :grandmaster].freeze
 
   attr_accessor :win_streak, :loss_streak
-  attr_writer :group_members
+  attr_writer :group_members, :heroes
 
   belongs_to :account
   belongs_to :map, required: false
@@ -92,6 +92,20 @@ class Match < ApplicationRecord
     else
       :grandmaster
     end
+  end
+
+  def self.prefill_heroes(matches)
+    heroes_by_id = Hero.order_by_name.map { |hero| [hero.id, hero] }.to_h
+    ids_in_order = heroes_by_id.keys
+    matches.each do |match|
+      heroes_by_id_for_match = heroes_by_id.slice(*match.hero_ids).
+        sort_by { |id, _hero| ids_in_order.index(id) }.to_h
+      match.heroes = heroes_by_id_for_match.values
+    end
+  end
+
+  def heroes
+    @heroes ||= Hero.where(id: hero_ids).order_by_name
   end
 
   def self.prefill_group_members(matches, user:)

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -146,11 +146,7 @@ class Match < ApplicationRecord
   end
 
   def hero_names
-    if association(:heroes).loaded?
-      heroes.map(&:name).sort
-    else
-      heroes.order_by_name.pluck(:name)
-    end
+    heroes.map(&:name)
   end
 
   def placement_char

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -95,6 +95,17 @@ class Match < ApplicationRecord
     end
   end
 
+  def self.count_by_hero_id(scope: nil)
+    matches_played_by_hero_id = Hash.new(0)
+    matches = (scope || Match).select(:hero_ids)
+    matches.each do |match|
+      match.hero_ids.each do |hero_id|
+        matches_played_by_hero_id[hero_id] += 1
+      end
+    end
+    matches_played_by_hero_id.sort_by { |_hero_id, match_count| -match_count }.to_h
+  end
+
   def self.prefill_heroes(matches)
     heroes_by_id = Hero.order_by_name.map { |hero| [hero.id, hero] }.to_h
     ids_in_order = heroes_by_id.keys

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -422,7 +422,7 @@ class Match < ApplicationRecord
   def hero_ids_exist
     return if hero_ids.empty?
     valid_hero_ids = Hero.pluck(:id)
-    invalid_hero_ids = valid_hero_ids - hero_ids
+    invalid_hero_ids = hero_ids - valid_hero_ids
     if invalid_hero_ids.any?
       errors.add(:hero_ids, "contains invalid values: #{invalid_hero_ids.map(&:to_s).join(', ')}")
     end

--- a/app/models/match_exporter.rb
+++ b/app/models/match_exporter.rb
@@ -26,9 +26,9 @@ class MatchExporter
   private
 
   def matches_to_export
-    matches = @account.matches.in_season(@season).
-      includes(:prior_match, :heroes, :map).ordered_by_time
+    matches = @account.matches.in_season(@season).includes(:prior_match, :map).ordered_by_time
     Match.prefill_group_members(matches, user: @account.user)
+    Match.prefill_heroes(matches)
     matches
   end
 end

--- a/app/models/match_hero.rb
+++ b/app/models/match_hero.rb
@@ -1,5 +1,0 @@
-class MatchHero < ApplicationRecord
-  self.table_name = 'heroes_matches'
-
-  belongs_to :match, required: false
-end

--- a/app/models/match_importer.rb
+++ b/app/models/match_importer.rb
@@ -63,18 +63,17 @@ class MatchImporter
       match.set_friends_from_names friend_names
     end
 
-    unless match.save
-      errors << match.errors
-    end
-
-    if match.persisted? && (hero_name_str = row['heroes']).present?
+    if (hero_name_str = row['heroes']).present?
       hero_names = split_string(hero_name_str)
       heroes = hero_names.map do |name|
         flat_name = Hero.flatten_name(name)
         heroes_by_name[flat_name]
       end
-      heroes = heroes.compact
-      heroes.each { |hero| match.heroes << hero }
+      match.heroes = heroes.compact
+    end
+
+    unless match.save
+      errors << match.errors
     end
 
     match

--- a/app/views/accounts/_heroes_list.html.erb
+++ b/app/views/accounts/_heroes_list.html.erb
@@ -5,11 +5,6 @@
 %>
 
 <% heroes.each do |hero, match_count| %>
-  <div class="d-flex flex-items-center mb-1 hero-list-item">
-    <%= image_tag("heroes/#{hero.slug}.png", alt: hero.name, class: 'flex-shrink-0 rounded-2 d-inline-block mr-2 hero-portrait', width: 30, height: 30) %>
-    <span class="d-inline-block hero-name text-bold mr-2"><%= hero %></span>
-    <span aria-label="<%= number_with_delimiter(match_count) %> <%= 'match'.pluralize(match_count) %>" class="hero-bar-container tooltipped tooltipped-w d-inline-block">
-      <span class="hero-bar hero-bar-<%= hero.slug %> d-inline-block rounded-2" style="width: <%= hero_bar_width(match_count, max_match_count, total_match_count) %>%"></span>
-    </span>
-  </div>
+  <%= hero_bar(hero, match_count: match_count, max_match_count: max_match_count,
+               total_match_count: total_match_count) %>
 <% end %>

--- a/app/views/seasons/_hero_bar.html.erb
+++ b/app/views/seasons/_hero_bar.html.erb
@@ -1,7 +1,0 @@
-<div aria-label="<%= pluralize(match_count, 'match') %>" class="tooltipped tooltipped-s d-flex flex-items-center mb-1">
-  <%= image_tag("heroes/#{hero.slug}.png", alt: hero.name, class: 'flex-shrink-0 rounded-2 d-inline-block mr-2 hero-portrait', width: 30, height: 30) %>
-  <span class="d-inline-block hero-name text-bold mr-2"><%= hero %></span>
-  <span class="hero-bar-container d-inline-block">
-    <span class="hero-bar hero-bar-<%= hero.slug %> d-inline-block rounded-2" style="width: <%= hero_bar_width(match_count, max_hero_match_count, total_matches) %>%"></span>
-  </span>
-</div>

--- a/app/views/trends/_heroes_played.html.erb
+++ b/app/views/trends/_heroes_played.html.erb
@@ -9,10 +9,9 @@
     <h3 class="h3 text-center mb-2">Heroes played</h3>
     <div>
       <% visible_heroes.each do |hero| %>
-        <%= render partial: 'seasons/hero_bar',
-                   locals: { match_count: match_counts_by_hero[hero], hero: hero,
-                             max_hero_match_count: max_hero_match_count,
-                             total_matches: total_matches } %>
+        <%= hero_bar(hero, match_count: match_counts_by_hero[hero],
+                     max_match_count: max_hero_match_count,
+                     total_match_count: total_matches) %>
       <% end %>
     </div>
     <% if hidden_heroes.any? %>
@@ -21,10 +20,9 @@
       </button>
       <div id="remaining-heroes" class="d-none">
         <% hidden_heroes.each do |hero| %>
-          <%= render partial: 'seasons/hero_bar',
-                     locals: { match_count: match_counts_by_hero[hero], hero: hero,
-                               max_hero_match_count: max_hero_match_count,
-                               total_matches: total_matches } %>
+          <%= hero_bar(hero, match_count: match_counts_by_hero[hero],
+                       max_match_count: max_hero_match_count,
+                       total_match_count: total_matches) %>
         <% end %>
       </div>
     <% end %>

--- a/db/migrate/20180317202258_add_hero_ids_to_matches.rb
+++ b/db/migrate/20180317202258_add_hero_ids_to_matches.rb
@@ -1,0 +1,19 @@
+class AddHeroIdsToMatches < ActiveRecord::Migration[5.1]
+  def up
+    add_column :matches, :hero_ids, :integer, array: true, default: [], null: false
+
+    execute <<-SQL
+      UPDATE matches SET hero_ids = agg_hero_ids
+      FROM (
+        SELECT match_id, ARRAY_AGG(hero_id ORDER BY hero_id) AS agg_hero_ids
+        FROM heroes_matches
+        GROUP BY match_id
+      ) AS heroes_matches
+      WHERE heroes_matches.match_id = matches.id
+    SQL
+  end
+
+  def down
+    remove_column :matches, :hero_ids
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180316235009) do
+ActiveRecord::Schema.define(version: 20180317202258) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -89,6 +89,7 @@ ActiveRecord::Schema.define(version: 20180316235009) do
     t.boolean "enemy_leaver"
     t.boolean "ally_leaver"
     t.integer "group_member_ids", default: [], null: false, array: true
+    t.integer "hero_ids", default: [], null: false, array: true
     t.index ["account_id"], name: "index_matches_on_account_id"
     t.index ["ally_leaver"], name: "index_matches_on_ally_leaver"
     t.index ["ally_thrower"], name: "index_matches_on_ally_thrower"

--- a/test/controllers/admin_controller_test.rb
+++ b/test/controllers/admin_controller_test.rb
@@ -22,13 +22,12 @@ class AdminControllerTest < ActionDispatch::IntegrationTest
   test 'loads successfully for admin' do
     admin_account = create(:account, admin: true)
     userless_account = create(:account, user: nil)
-    match1 = create(:match, season: 1)
-    match1.heroes << heroes(:mercy)
+    match1 = create(:match, season: 1, heroes: [heroes(:mercy)])
     user = create(:user)
     account = create(:account, user: user)
     friend = create(:friend, user: user)
-    match2 = create(:match, result: :win, season: 2, account: account, group_member_ids: [friend.id])
-    match2.heroes << heroes(:ana)
+    match2 = create(:match, result: :win, season: 2, account: account,
+                    group_member_ids: [friend.id], heroes: [heroes(:ana)])
 
     sign_in_as(admin_account)
     get '/admin'

--- a/test/controllers/trends_controller_test.rb
+++ b/test/controllers/trends_controller_test.rb
@@ -13,11 +13,11 @@ class TrendsControllerTest < ActionDispatch::IntegrationTest
     @hero2 = heroes(:genji)
     @friend = create(:friend, user: @user)
     @match1 = create(:match, account: @account, season: @season.number,
-                     result: :win, group_member_ids: [@friend.id])
-    @match1.heroes << @hero1
+                     result: :win, group_member_ids: [@friend.id],
+                     heroes: [@hero1])
     @match2 = create(:match, account: @account, season: @season.number,
-                     prior_match: @match1, group_member_ids: [@friend.id])
-    @match2.heroes << @hero2
+                     prior_match: @match1, group_member_ids: [@friend.id],
+                     heroes: [@hero2])
   end
 
   test 'all seasons/accounts page redirects anonymous user' do

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -6,16 +6,10 @@ class AccountTest < ActiveSupport::TestCase
   test 'most_played_heroes returns a hash of the heroes and match counts' do
     account = create(:account)
     other_account = create(:account)
-    match1 = create(:match, account: account)
-    match1.heroes << heroes(:ana)
-    match1.heroes << heroes(:mercy)
-    match2 = create(:match, account: account)
-    match2.heroes << heroes(:ana)
-    match2.heroes << heroes(:mercy)
-    match3 = create(:match, account: account)
-    match3.heroes << heroes(:mccree)
-    other_match = create(:match, account: other_account)
-    other_match.heroes << heroes(:mccree)
+    match1 = create(:match, account: account, heroes: [heroes(:ana), heroes(:mercy)])
+    match2 = create(:match, account: account, heroes: [heroes(:ana), heroes(:mercy)])
+    match3 = create(:match, account: account, heroes: [heroes(:mccree)])
+    other_match = create(:match, account: other_account, heroes: [heroes(:mccree)])
 
     expected = { heroes(:ana) => 2, heroes(:mercy) => 2, heroes(:mccree) => 1 }
     assert_equal expected, account.most_played_heroes

--- a/test/models/hero_test.rb
+++ b/test/models/hero_test.rb
@@ -7,16 +7,10 @@ class HeroTest < ActiveSupport::TestCase
   test 'most_played returns a hash of the heroes and match counts' do
     account = create(:account)
     other_account = create(:account)
-    match1 = create(:match, account: account)
-    match1.heroes << heroes(:ana)
-    match1.heroes << heroes(:mercy)
-    match2 = create(:match, account: account)
-    match2.heroes << heroes(:ana)
-    match2.heroes << heroes(:mercy)
-    match3 = create(:match, account: account)
-    match3.heroes << heroes(:mccree)
-    other_match = create(:match, account: other_account)
-    other_match.heroes << heroes(:mccree)
+    match1 = create(:match, account: account, heroes: [heroes(:ana), heroes(:mercy)])
+    match2 = create(:match, account: account, heroes: [heroes(:ana), heroes(:mercy)])
+    match3 = create(:match, account: account, heroes: [heroes(:mccree)])
+    other_match = create(:match, account: other_account, heroes: [heroes(:mccree)])
 
     expected = { heroes(:ana) => 2, heroes(:mercy) => 2, heroes(:mccree) => 2 }
     assert_equal expected, Hero.most_played

--- a/test/models/match_exporter_test.rb
+++ b/test/models/match_exporter_test.rb
@@ -20,17 +20,12 @@ class MatchExporterTest < ActiveSupport::TestCase
 
     @match1 = create(:match, season: @season, account: @account, rank: 1234,
                      map: nil, prior_match: nil)
-
     @match2 = create(:match, season: @season, account: @account, rank: 1254,
-                     map: @map1, ally_thrower: true, prior_match: @match1, time_of_day: :evening)
-    @match2.heroes << @hero3
-
+                     map: @map1, ally_thrower: true, prior_match: @match1, time_of_day: :evening,
+                     heroes: [@hero3])
     @match3 = create(:match, season: @season, account: @account, rank: 1273,
                      map: @map2, enemy_leaver: true, prior_match: @match2, time_of_day: :morning,
-                     day_of_week: :weekday)
-    @match3.heroes << @hero1
-    @match3.heroes << @hero2
-
+                     day_of_week: :weekday, heroes: [@hero1, @hero2])
     @match4 = create(:match, season: @season, account: @account, rank: 1295,
                      map: @map1, prior_match: @match3, comment: 'this is so cool',
                      group_member_ids: [@friend1.id, @friend2.id])

--- a/test/models/match_test.rb
+++ b/test/models/match_test.rb
@@ -1,6 +1,15 @@
 require 'test_helper'
 
 class MatchTest < ActiveSupport::TestCase
+  fixtures :heroes
+
+  test 'requires hero_ids to include only valid hero IDs' do
+    match = build(:match, hero_ids: [heroes(:ana).id, -1, heroes(:mercy).id])
+
+    refute_predicate match, :valid?
+    assert_includes match.errors.messages[:hero_ids], 'contains invalid values: -1'
+  end
+
   test 'prefill_group_members sets group members list from group_member_ids' do
     user = create(:user)
     account = create(:account, user: user)


### PR DESCRIPTION
This is like #71 but for heroes_matches instead of match_friends.

- Add hero_ids array field to matches table, populated from the heroes_matches table
- Update everything to work with heroes being on the match itself and not in a relation
- Add #prefill_heroes to avoid an n+1 query looking at the heroes in a match