### PR TITLE
Allow admin to view unshared season if param given

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -62,9 +62,14 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def allow_admin_bypass?
+    signed_in? && current_account.admin? && params[:admin].present?
+  end
+
   def ensure_season_is_visible
     return if signed_in? && current_user == @account.user
     return if @account.season_is_public?(@season)
+    return if allow_admin_bypass?
     redirect_to profile_path(@account)
   end
 

--- a/test/controllers/matches_controller_test.rb
+++ b/test/controllers/matches_controller_test.rb
@@ -27,6 +27,26 @@ class MatchesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to profile_path(account)
   end
 
+  test 'allows admin to view unshared season when admin param is given' do
+    admin_account = create(:account, admin: true)
+    other_account = create(:account)
+
+    sign_in_as(admin_account)
+    get "/season/#{@season}/#{other_account.to_param}", params: { admin: 1 }
+
+    assert_response :ok
+  end
+
+  test 'redirects admin from unshared season when admin param is omitted' do
+    admin_account = create(:account, admin: true)
+    other_account = create(:account)
+
+    sign_in_as(admin_account)
+    get "/season/#{@season}/#{other_account.to_param}"
+
+    assert_redirected_to profile_path(other_account)
+  end
+
   test 'index page loads successfully for the user who owns the account' do
     account = create(:account)
     create(:match, account: account, season: @season.number)

--- a/test/controllers/matches_controller_test.rb
+++ b/test/controllers/matches_controller_test.rb
@@ -37,6 +37,16 @@ class MatchesControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
   end
 
+  test 'redirects non-admin from unshared season when admin param is given' do
+    account = create(:account)
+    other_account = create(:account)
+
+    sign_in_as(account)
+    get "/season/#{@season}/#{other_account.to_param}", params: { admin: 1 }
+
+    assert_redirected_to profile_path(other_account)
+  end
+
   test 'redirects admin from unshared season when admin param is omitted' do
     admin_account = create(:account, admin: true)
     other_account = create(:account)

--- a/test/controllers/users/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/users/omniauth_callbacks_controller_test.rb
@@ -3,6 +3,8 @@ require 'test_helper'
 class Users::OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
+  fixtures :seasons
+
   test 'creates an account and user when account does not exist' do
     uid = '123'
     battletag = 'Somebody#1234'

--- a/test/controllers/users/sessions_controller_test.rb
+++ b/test/controllers/users/sessions_controller_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class Users::SessionsControllerTest < ActionDispatch::IntegrationTest
+  fixtures :seasons
+
   test 'user is redirected to home on logout' do
     account = create(:account)
 


### PR DESCRIPTION
For #69. This will let me look at https://www.competiwatch.com/season/9/Bkid2-1719 to reproduce the error without sharing the user's season publicly.