### PR TITLE
Update prior_match when a match is deleted

### DIFF
--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -19,6 +19,7 @@ class Match < ApplicationRecord
   after_create :reset_career_high, if: :saved_change_to_rank?
   after_save :delete_straggler_friends_on_save, if: :saved_change_to_group_member_ids?
   after_destroy :delete_straggler_friends_on_destroy
+  after_destroy :update_next_match_prior_match
 
   validates :season, presence: true,
     numericality: { only_integer: true, greater_than_or_equal_to: 1 }
@@ -443,5 +444,15 @@ class Match < ApplicationRecord
     if invalid_hero_ids.any?
       errors.add(:hero_ids, "contains invalid values: #{invalid_hero_ids.map(&:to_s).join(', ')}")
     end
+  end
+
+  def update_next_match_prior_match
+    return unless prior_match_id
+
+    match_after = next_match
+    return unless match_after
+
+    match_after.prior_match_id = prior_match_id
+    match_after.save
   end
 end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -344,6 +344,11 @@ class Match < ApplicationRecord
     end
   end
 
+  def next_match
+    return unless id && account && season
+    account.matches.in_season(season).where(prior_match_id: id).first
+  end
+
   private
 
   def reset_career_high

--- a/test/models/match_test.rb
+++ b/test/models/match_test.rb
@@ -1,7 +1,15 @@
 require 'test_helper'
 
 class MatchTest < ActiveSupport::TestCase
-  fixtures :heroes
+  fixtures :heroes, :seasons
+
+  test 'next_match returns the match following this one in the season' do
+    account = create(:account)
+    match1 = create(:match, account: account, season: 1)
+    match2 = create(:match, account: account, season: 1, prior_match: match1)
+
+    assert_equal match2, match1.next_match
+  end
 
   test 'requires hero_ids to include only valid hero IDs' do
     match = build(:match, hero_ids: [heroes(:ana).id, -1, heroes(:mercy).id])

--- a/test/models/match_test.rb
+++ b/test/models/match_test.rb
@@ -11,6 +11,17 @@ class MatchTest < ActiveSupport::TestCase
     assert_equal match2, match1.next_match
   end
 
+  test 'updates prior_match on destroy' do
+    account = create(:account)
+    match1 = create(:match, account: account, season: 1)
+    match2 = create(:match, account: account, season: 1, prior_match: match1)
+    match3 = create(:match, account: account, season: 1, prior_match: match2)
+
+    match2.destroy!
+
+    assert_equal match1, match3.reload.prior_match
+  end
+
   test 'requires hero_ids to include only valid hero IDs' do
     match = build(:match, hero_ids: [heroes(:ana).id, -1, heroes(:mercy).id])
 


### PR DESCRIPTION
Addresses what I found in https://github.com/cheshire137/competiwatch/issues/69#issuecomment-373958756. Say you have match1 -> match2 -> match3. If you delete match2, now match3's prior match will be updated to match1, instead of still pointing at the now-deleted match2.