### PR TITLE
Clean up old tables, update profile when region/platform changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ yarn-debug.log*
 yarn-error.log*
 .yarn-integrity
 coverage
+*.dump

--- a/README.md
+++ b/README.md
@@ -100,6 +100,18 @@ heroku certs:update /etc/letsencrypt/live/your-domain/fullchain.pem /etc/letsenc
 
 See [Renewing certificates with Certbot](https://certbot.eff.org/docs/using.html#renewing-certificates).
 
+### Database Backups
+
+To back up the database from Heroku, you can use `bin/backup-database` which will
+capture the current state of the Heroku database, download it, and move the dump
+file to the directory specified in the `BACKUP_DIR` environment variable.
+
+Example:
+
+```bash
+BACKUP_DIR=~/Dropbox bin/backup-database
+```
+
 ## Admin Accounts
 
 You can set some accounts as administrators that can see general data such as how many

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -27,8 +27,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
           current_user.reload
           account.reload
 
-          SetProfileDataJob.perform_later(account.id)
-
           { notice: "Successfully linked #{battletags.join(', ')}." }
         else
           if account.changed?

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -208,10 +208,14 @@ class Account < ApplicationRecord
     VALID_REGIONS[region]
   end
 
+  def api_response
+    overwatch_api.response
+  end
+
   private
 
   def overwatch_api
-    OverwatchAPI.new(battletag: battletag, region: region, platform: platform)
+    @overwatch_api ||= OverwatchAPI.new(battletag: battletag, region: region, platform: platform)
   end
 
   def overwatch_api_profile_cache_key

--- a/app/models/overwatch_api.rb
+++ b/app/models/overwatch_api.rb
@@ -2,10 +2,13 @@ class OverwatchAPI
   include HTTParty
   base_uri 'ow-api.herokuapp.com'
 
+  attr_reader :response
+
   def initialize(battletag:, region:, platform:)
     @battletag = User.parameterize(battletag)
     @region = region
     @platform = platform
+    @response = nil
   end
 
   def profile_url
@@ -13,8 +16,8 @@ class OverwatchAPI
   end
 
   def profile
-    resp = self.class.get(profile_url)
-    resp.parsed_response if resp.success?
+    @response = self.class.get(profile_url)
+    return @response.parsed_response if @response.success?
   end
 
   def stats_url
@@ -22,7 +25,7 @@ class OverwatchAPI
   end
 
   def stats
-    resp = self.class.get(stats_url)
-    resp.parsed_response if resp.success?
+    @response = self.class.get(stats_url)
+    return @response.parsed_response if @response.success?
   end
 end

--- a/bin/backup-database
+++ b/bin/backup-database
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+_dest_dir=${BACKUP_DIR:=~/Documents}
+if [ ! -d $_dest_dir ]; then
+  echo "Backup destination directory $_dest_dir does not exist"
+  exit 1
+fi
+
+heroku pg:backups:capture
+heroku pg:backups:download
+
+_now=$(date +"%Y-%m-%d")
+_dest_filename="competiwatch-prod-$_now.dump"
+_dest_path="$_dest_dir/$_dest_filename"
+
+echo "Backing up to $_dest_path"
+mv latest.dump $_dest_path

--- a/db/migrate/20180318170010_drop_heroes_matches.rb
+++ b/db/migrate/20180318170010_drop_heroes_matches.rb
@@ -1,0 +1,13 @@
+class DropHeroesMatches < ActiveRecord::Migration[5.1]
+  def up
+    drop_table :heroes_matches
+  end
+
+  def down
+    create_table "heroes_matches" do |t|
+      t.integer "hero_id", null: false
+      t.integer "match_id", null: false
+      t.index ["hero_id", "match_id"], name: "index_heroes_matches_on_hero_id_and_match_id", unique: true
+    end
+  end
+end

--- a/db/migrate/20180318170107_drop_match_friends.rb
+++ b/db/migrate/20180318170107_drop_match_friends.rb
@@ -1,0 +1,13 @@
+class DropMatchFriends < ActiveRecord::Migration[5.1]
+  def up
+    drop_table :match_friends
+  end
+
+  def down
+    create_table "match_friends" do |t|
+      t.integer "match_id", null: false
+      t.integer "friend_id", null: false
+      t.index ["match_id", "friend_id"], name: "index_match_friends_on_match_id_and_friend_id", unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180317202258) do
+ActiveRecord::Schema.define(version: 20180318170010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,12 +47,6 @@ ActiveRecord::Schema.define(version: 20180317202258) do
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_heroes_on_name", unique: true
     t.index ["role"], name: "index_heroes_on_role"
-  end
-
-  create_table "heroes_matches", force: :cascade do |t|
-    t.integer "hero_id", null: false
-    t.integer "match_id", null: false
-    t.index ["hero_id", "match_id"], name: "index_heroes_matches_on_hero_id_and_match_id", unique: true
   end
 
   create_table "maps", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180318170010) do
+ActiveRecord::Schema.define(version: 20180318170107) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,12 +57,6 @@ ActiveRecord::Schema.define(version: 20180318170010) do
     t.string "slug"
     t.string "color", limit: 16, default: "#ffffff", null: false
     t.index ["name"], name: "index_maps_on_name", unique: true
-  end
-
-  create_table "match_friends", force: :cascade do |t|
-    t.integer "match_id", null: false
-    t.integer "friend_id", null: false
-    t.index ["match_id", "friend_id"], name: "index_match_friends_on_match_id_and_friend_id", unique: true
   end
 
   create_table "matches", force: :cascade do |t|


### PR DESCRIPTION
This branch:

- Removes heroes_matches, an unused table
- Removes match_friends, an unused table
- Enqueues a job to update the account's avatar, rank, etc. whenever the platform or region changes, since those affect the profile URL fetched from the API -- fixes #80 