### PR TITLE
Add admin tools to delete old, unused accounts

### DIFF
--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -10,6 +10,11 @@ class Admin::AccountsController < ApplicationController
     @deletable_accounts = Account.without_matches.sole_accounts.not_recently_updated
   end
 
+  def prune
+    PruneOldAccountsJob.perform_later
+    redirect_to admin_accounts_path, notice: 'Deleting old sole accounts without matches...'
+  end
+
   def update
     unless params[:user_id] && params[:account_id]
       flash[:error] = 'Please specify a user and an account.'

--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -7,6 +7,7 @@ class Admin::AccountsController < ApplicationController
     @user_options = [['--', '']] + User.order_by_battletag.map { |user| [user.battletag, user.id] }
     @userless_account_options = [['--', '']] +
       @userless_accounts.map { |account| [account.battletag, account.id] }
+    @deletable_accounts = Account.without_matches.sole_accounts.not_recently_updated
   end
 
   def update

--- a/app/controllers/admin/home_controller.rb
+++ b/app/controllers/admin/home_controller.rb
@@ -21,5 +21,6 @@ class Admin::HomeController < ApplicationController
     @user_options = [['--', '']] + User.order_by_battletag.map { |user| [user.battletag, user.id] }
     @top_heroes = Hero.most_played
     @total_users_with_single_account = User.total_by_account_count(num_accounts: 1)
+    @total_accounts_without_matches = Account.without_matches.count
   end
 end

--- a/app/controllers/admin/home_controller.rb
+++ b/app/controllers/admin/home_controller.rb
@@ -20,5 +20,6 @@ class Admin::HomeController < ApplicationController
     @active_user_count = User.active.count
     @user_options = [['--', '']] + User.order_by_battletag.map { |user| [user.battletag, user.id] }
     @top_heroes = Hero.most_played
+    @total_users_with_single_account = User.total_by_account_count(num_accounts: 1)
   end
 end

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -9,7 +9,7 @@ module AccountsHelper
       safe_join([
         avatar_for(account),
         content_tag(:span, account, class: 'text-bold')
-      ])
+      ], ' ')
     end
   end
 

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -1,4 +1,18 @@
 module AccountsHelper
+  def link_to_account(account, new_tab: true)
+    link_options = {}
+    if new_tab
+      link_options[:target] = '_blank'
+      link_options[:rel] = 'noopener noreferrer'
+    end
+    link_to(profile_path(account)) do
+      safe_join([
+        avatar_for(account),
+        content_tag(:span, account, class: 'text-bold')
+      ])
+    end
+  end
+
   def hero_tldr_roles(heroes)
     roles = heroes.map(&:role)
     role_counts = {}

--- a/app/jobs/prune_old_accounts_job.rb
+++ b/app/jobs/prune_old_accounts_job.rb
@@ -1,0 +1,16 @@
+class PruneOldAccountsJob < ApplicationJob
+  queue_as :default
+
+  def perform(*args)
+    accounts = Account.without_matches.sole_accounts.not_recently_updated.includes(:user)
+    if accounts.count < 1
+      Rails.logger.info 'PruneOldAccountsJob no old single accounts without matches'
+      return
+    end
+
+    Rails.logger.info "PruneOldAccountsJob deleting #{accounts.count} account(s) and their users"
+    users = accounts.map(&:user)
+    accounts.destroy_all
+    users.map(&:destroy)
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -57,7 +57,7 @@ class Account < ApplicationRecord
 
   alias_attribute :to_s, :battletag
 
-  has_many :matches
+  has_many :matches, dependent: :restrict_with_exception
   has_many :season_shares, dependent: :destroy
 
   def self.find_by_param(battletag_param)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -39,7 +39,7 @@ class Account < ApplicationRecord
     batch_size = 100
     scope = where(nil)
     account_ids_with_matches.each_slice(batch_size) do |account_ids|
-      scope = scope.where('id NOT IN (?)', account_ids)
+      scope = scope.where('accounts.id NOT IN (?)', account_ids)
     end
     scope
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -44,6 +44,13 @@ class Account < ApplicationRecord
     scope
   end
 
+  scope :sole_accounts, -> do
+    joins(:user).joins('LEFT OUTER JOIN accounts other_accounts ' \
+                       'ON users.id=other_accounts.user_id ' \
+                       'AND other_accounts.id <> accounts.id').
+      where('other_accounts.id IS NULL')
+  end
+
   after_update :remove_default, if: :saved_change_to_user_id?
   after_update :refresh_profile_data, if: :region_or_platform_changed?
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -33,6 +33,7 @@ class Account < ApplicationRecord
   scope :order_by_battletag, ->{ order('LOWER(battletag) ASC') }
   scope :without_user, ->{ where(user_id: nil) }
   scope :with_rank, ->{ where('rank IS NOT NULL') }
+  scope :not_recently_updated, ->{ where('accounts.updated_at <= ?', 2.months.ago) }
 
   scope :without_matches, -> do
     account_ids_with_matches = Match.group(:account_id).pluck(:account_id)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -57,7 +57,7 @@ class Account < ApplicationRecord
 
   alias_attribute :to_s, :battletag
 
-  has_many :matches, dependent: :destroy
+  has_many :matches
   has_many :season_shares, dependent: :destroy
 
   def self.find_by_param(battletag_param)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -34,6 +34,16 @@ class Account < ApplicationRecord
   scope :without_user, ->{ where(user_id: nil) }
   scope :with_rank, ->{ where('rank IS NOT NULL') }
 
+  scope :without_matches, -> do
+    account_ids_with_matches = Match.group(:account_id).pluck(:account_id)
+    batch_size = 100
+    scope = where(nil)
+    account_ids_with_matches.each_slice(batch_size) do |account_ids|
+      scope = scope.where('id NOT IN (?)', account_ids)
+    end
+    scope
+  end
+
   after_update :remove_default, if: :saved_change_to_user_id?
   after_update :refresh_profile_data, if: :region_or_platform_changed?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,19 @@ class User < ApplicationRecord
     where(id: share_user_ids | match_user_ids)
   end
 
+  # Public: See how many users there are with the specified number of linked accounts.
+  def self.total_by_account_count(num_accounts:)
+    num_accounts = num_accounts.to_i
+    query = <<-SQL
+      SELECT COUNT(*) FROM (
+        SELECT user_id, COUNT(*) FROM accounts GROUP BY user_id
+      ) accounts_by_user WHERE count = #{num_accounts}
+    SQL
+    result = ActiveRecord::Base.connection.exec_query(query)
+    row = result.rows.first
+    row.first
+  end
+
   def name
     battletag.split('#').first
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   devise :omniauthable, omniauth_providers: [:bnet]
 
-  has_many :accounts, dependent: :destroy
+  has_many :accounts, dependent: :restrict_with_exception
   has_many :friends, dependent: :destroy
   has_many :matches, through: :accounts
   has_many :season_shares, through: :accounts

--- a/app/views/admin/accounts/index.html.erb
+++ b/app/views/admin/accounts/index.html.erb
@@ -3,10 +3,7 @@
 <ul class="list-style-none mb-4">
   <% @accounts.each_with_index do |account, i| %>
     <li class="<%= 'border-top mt-2 pt-2' if i > 0 %>">
-      <a href="<%= profile_path(account) %>" target="_blank" rel="noopener noreferrer">
-        <%= avatar_for(account) %>
-        <span class="text-bold"><%= account %></span>
-      </a>
+      <%= link_to_account(account) %>
       <% if account.rank %>
         <span class="d-inline-block mx-2">&middot;</span>
         <%= rank_image(account.rank, classes: 'flex-shrink-0 rank-fit-height',
@@ -46,7 +43,7 @@
       <h2 class="h2 mb-2">Accounts without users</h2>
       <ul class="list-style-none">
         <% @userless_accounts.each do |account| %>
-          <li><%= account %></li>
+          <li><%= link_to_account(account) %></li>
         <% end %>
       </ul>
     </div>

--- a/app/views/admin/accounts/index.html.erb
+++ b/app/views/admin/accounts/index.html.erb
@@ -48,6 +48,11 @@
           </li>
         <% end %>
       </ul>
+      <%= form_tag admin_prune_accounts_path, method: :delete do %>
+        <button type="submit" class="btn btn-danger" data-confirm="Are you sure you want to delete these accounts? They don't have any matches logged.">
+          Prune old accounts
+        </button>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/admin/accounts/index.html.erb
+++ b/app/views/admin/accounts/index.html.erb
@@ -37,11 +37,26 @@
   </div>
 <% end %>
 
+<% if @deletable_accounts.any? %>
+  <div class="clearfix">
+    <div class="col-md-6 mb-4 float-left">
+      <h2 class="h2 mb-2">Deletable accounts</h2>
+      <ul class="list-style-none test-deletable-accounts">
+        <% @deletable_accounts.each_with_index do |account, i| %>
+          <li class="<%= 'border-top mt-2 pt-2' if i > 0 %>">
+            <%= link_to_account(account) %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+<% end %>
+
 <% if @userless_accounts.any? %>
   <div class="clearfix">
     <div class="col-md-6 mb-4 float-left">
       <h2 class="h2 mb-2">Accounts without users</h2>
-      <ul class="list-style-none">
+      <ul class="list-style-none test-userless-accounts">
         <% @userless_accounts.each do |account| %>
           <li><%= link_to_account(account) %></li>
         <% end %>

--- a/app/views/admin/home/_latest_accounts.html.erb
+++ b/app/views/admin/home/_latest_accounts.html.erb
@@ -4,10 +4,7 @@
   <% latest_accounts.each do |account| %>
     <li<% if i > 0 %> class="border-top mt-2 pt-2"<% end %>>
       <div class="d-flex flex-items-start">
-        <a href="<%= profile_path(account) %>" target="_blank" rel="noopener noreferrer">
-          <%= avatar_for(account) %>
-          <span class="text-bold"><%= account %></span>
-        </a>
+        <%= link_to_account(account) %>
         <% if account.rank %>
           <span class="d-inline-block mx-2">&middot;</span>
           <%= rank_image(account.rank, classes: 'flex-shrink-0',

--- a/app/views/admin/home/_latest_matches.html.erb
+++ b/app/views/admin/home/_latest_matches.html.erb
@@ -7,10 +7,7 @@
 <ul class="mb-4 list-style-none">
   <% matches.each_with_index do |match, i| %>
     <li<% if i > 0 %> class="mt-1"<% end %>>
-      <a href="<%= profile_path(match.account) %>" target="_blank" rel="noopener noreferrer">
-        <%= avatar_for(match.account) %>
-        <%= match.account %>
-      </a>
+      <%= link_to_account(match.account) %>
       &middot;
       <%= match_result(match) %>
       <% if map = match.map %>

--- a/app/views/admin/home/_latest_matches.html.erb
+++ b/app/views/admin/home/_latest_matches.html.erb
@@ -4,19 +4,26 @@
     *From other users
   </span>
 </h2>
-<ul class="mb-4 list-style-none">
+<ul class="mb-4 list-style-none test-latest-matches">
   <% matches.each_with_index do |match, i| %>
     <li<% if i > 0 %> class="mt-1"<% end %>>
       <%= link_to_account(match.account) %>
       &middot;
       <%= match_result(match) %>
+      <% if match.placement? %>
+        &middot;
+        <span class="text-gray">Placement</span>
+      <% elsif match.placement_log? %>
+        &middot;
+        <span class="text-gray">Placement log</span>
+      <% end %>
       <% if map = match.map %>
         &middot;
         <span class="background-<%= map.slug %> px-1 rounded-1"><%= map %></span>
       <% end %>
       <% if (hero_count = match.heroes.count) > 0 %>
         &middot;
-        <%= pluralize(hero_count, 'hero') %>
+        <span><%= pluralize(hero_count, 'hero') %></span>
       <% end %>
       <% if (friend_count = match.friend_count) > 0 %>
         &middot;

--- a/app/views/admin/home/_top_accounts.html.erb
+++ b/app/views/admin/home/_top_accounts.html.erb
@@ -4,10 +4,7 @@
   <% top_accounts.each do |account, match_count| %>
     <li<% if i > 0 %> class="border-top mt-2 pt-2"<% end %>>
       <div class="d-flex flex-items-start">
-        <a href="<%= profile_path(account) %>" target="_blank" rel="noopener noreferrer">
-          <%= avatar_for(account) %>
-          <span class="text-bold"><%= account %></span>
-        </a>
+        <%= link_to_account(account) %>
         <span class="d-inline-block mx-2">&middot;</span>
         <%= number_with_delimiter match_count %>
         <%= 'match'.pluralize(match_count) %>

--- a/app/views/admin/home/index.html.erb
+++ b/app/views/admin/home/index.html.erb
@@ -15,6 +15,10 @@
         <strong><%= number_with_delimiter @account_count %></strong>
         <%= 'account'.pluralize(@account_count) %>
       </li>
+      <li>
+        <strong><%= number_with_delimiter @total_accounts_without_matches %></strong>
+        <%= 'account'.pluralize(@total_accounts_without_matches) %> without matches
+      </li>
     </ul>
   </div>
   <% if @top_rank || @average_rank || @bottom_rank %>

--- a/app/views/admin/home/index.html.erb
+++ b/app/views/admin/home/index.html.erb
@@ -63,9 +63,9 @@
       </li>
     </ul>
   </div>
-  <% if @top_season.present? %>
-    <div class="col-md-3 float-left">
-      <ul class="list-style-none">
+  <div class="col-md-3 float-left">
+    <ul class="list-style-none">
+      <% if @top_season.present? %>
         <li>
           <strong>Top season:</strong>
           Season <%= @top_season[0] %>
@@ -74,9 +74,13 @@
             <%= 'match'.pluralize(@top_season[1]) %>
           </div>
         </li>
-      </ul>
-    </div>
-  <% end %>
+      <% end %>
+      <li>
+        <strong><%= number_with_delimiter @total_users_with_single_account %></strong>
+        <%= 'user'.pluralize(@total_users_with_single_account) %> with single account
+      </li>
+    </ul>
+  </div>
 </div>
 
 <div class="clearfix mb-4">

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -34,10 +34,7 @@
           %>
           <li class="mt-1">
             <div class="d-flex flex-items-start">
-              <a href="<%= profile_path(account) %>" target="_blank" rel="noopener noreferrer">
-                <%= avatar_for(account) %>
-                <span class="text-bold"><%= account %></span>
-              </a>
+              <%= link_to_account(account) %>
               <% if details_class %>
                 <span class="d-inline-block mx-2">&middot;</span>
                 <button type="button" class="btn-link js-toggle-details" data-target=".<%= details_class %>">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do
   get '/admin/users' => 'admin/users#index', as: :admin_users
   post '/admin/users/merge' => 'admin/users#merge', as: :admin_merge_users
   get '/admin/accounts' => 'admin/accounts#index', as: :admin_accounts
+  delete '/admin/accounts/prune' => 'admin/accounts#prune', as: :admin_prune_accounts
   post '/admin/account' => 'admin/accounts#update', as: :admin_update_account
   get '/admin/seasons' => 'admin/seasons#index', as: :admin_seasons
   put '/admin/season' => 'admin/seasons#update', as: :admin_update_season

--- a/test/controllers/admin/accounts_controller_test.rb
+++ b/test/controllers/admin/accounts_controller_test.rb
@@ -15,12 +15,14 @@ class Admin::AccountsControllerTest < ActionDispatch::IntegrationTest
   test 'admin can view accounts' do
     admin_account = create(:account, admin: true)
     userless_account = create(:account, user: nil)
+    deletable_account = create(:account, updated_at: 1.year.ago)
 
     sign_in_as(admin_account)
     get '/admin/accounts'
 
     assert_response :ok
-    assert_select 'li', text: userless_account.battletag
+    assert_select '.test-userless-accounts li', text: userless_account.battletag
+    assert_select '.test-deletable-accounts li', text: deletable_account.battletag
   end
 
   test 'non-admin cannot edit accounts' do

--- a/test/controllers/admin/home_controller_test.rb
+++ b/test/controllers/admin/home_controller_test.rb
@@ -27,11 +27,18 @@ class Admin::HomeControllerTest < ActionDispatch::IntegrationTest
     friend = create(:friend, user: user)
     match2 = create(:match, result: :win, season: 2, account: account,
                     group_member_ids: [friend.id], heroes: [heroes(:ana)])
+    placement_match = create(:match, placement: true, season: 1)
+    placement_log_match = create(:match, placement: false, season: 1, map: nil,
+                                 prior_match: nil, rank: 3000)
 
     sign_in_as(admin_account)
     get '/admin'
 
     assert_response :ok
     assert_select 'button', text: /#{admin_account.name}/
+    assert_select '.test-latest-matches span', text: 'Placement log'
+    assert_select '.test-latest-matches span', text: 'Placement'
+    assert_select '.test-latest-matches span', text: 'Win'
+    assert_select '.test-latest-matches span', text: '1 hero'
   end
 end

--- a/test/jobs/prune_old_accounts_job_test.rb
+++ b/test/jobs/prune_old_accounts_job_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class PruneOldAccountsJobTest < ActiveJob::TestCase
+  test 'deletes old accounts and their users when they have no matches' do
+    user1 = create(:user)
+    user2 = create(:user)
+    old_account1 = create(:account, updated_at: 4.months.ago, user: user1)
+    old_account2 = create(:account, updated_at: 3.months.ago, user: user2)
+
+    assert_difference ['Account.count', 'User.count'], -2 do
+      PruneOldAccountsJob.perform_now
+    end
+
+    refute Account.exists?(old_account1.id)
+    refute Account.exists?(old_account2.id)
+    refute User.exists?(user1.id)
+    refute User.exists?(user2.id)
+  end
+
+  test 'will not delete recently updated account' do
+    create(:account, updated_at: 1.month.ago)
+
+    assert_no_difference ['Account.count', 'User.count'] do
+      PruneOldAccountsJob.perform_now
+    end
+  end
+
+  test 'will not delete old account with matches' do
+    account = create(:account, updated_at: 5.months.ago)
+    create(:match, account: account)
+
+    assert_no_difference ['Account.count', 'User.count'] do
+      PruneOldAccountsJob.perform_now
+    end
+  end
+
+  test 'will not delete old account without matches when its user has another account' do
+    user = create(:user)
+    create(:account, user: user, updated_at: 1.year.ago)
+    create(:account, user: user, updated_at: 7.months.ago)
+
+    assert_no_difference ['Account.count', 'User.count'] do
+      PruneOldAccountsJob.perform_now
+    end
+  end
+end

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -8,6 +8,20 @@ class AccountTest < ActiveSupport::TestCase
     clear_enqueued_jobs
   end
 
+  test 'sole_accounts returns accounts that are the sole account for their user' do
+    user1 = create(:user)
+    account1 = create(:account, user: user1)
+
+    user2 = create(:user)
+    account2 = create(:account, user: user2)
+    account3 = create(:account, user: user2)
+
+    user3 = create(:user)
+    account4 = create(:account, user: user3)
+
+    assert_equal [account1, account4], Account.sole_accounts
+  end
+
   test 'without_matches returns accounts that have not logged a match' do
     account1 = create(:account)
     create(:match, account: account1)

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -277,6 +277,21 @@ class AccountTest < ActiveSupport::TestCase
     assert_includes account.errors.messages[:battletag], "can't be blank"
   end
 
+  test 'raises exception when trying to delete account with matches' do
+    account = create(:account)
+    match1 = create(:match, account: account)
+    match2 = create(:match, account: account)
+
+    assert_no_difference 'Match.count' do
+      assert_raises ActiveRecord::DeleteRestrictionError do
+        account.reload.destroy
+      end
+    end
+
+    assert Match.exists?(match1.id)
+    assert Match.exists?(match2.id)
+  end
+
   test 'deletes season shares when deleted' do
     account = create(:account)
     share1 = create(:season_share, account: account, season: seasons(:one).number)

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -8,6 +8,19 @@ class AccountTest < ActiveSupport::TestCase
     clear_enqueued_jobs
   end
 
+  test 'without_matches returns accounts that have not logged a match' do
+    account1 = create(:account)
+    create(:match, account: account1)
+
+    account2 = create(:account)
+
+    account3 = create(:account)
+    create(:match, account: account3)
+    create(:match, account: account3)
+
+    assert_equal [account2], Account.without_matches
+  end
+
   test 'updates profile data when region changes' do
     account = create(:account, region: 'us')
     account.region = 'global'

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -8,6 +8,14 @@ class AccountTest < ActiveSupport::TestCase
     clear_enqueued_jobs
   end
 
+  test 'not_recently_updated returns accounts not updated for more than 2 months' do
+    old_account1 = create(:account, updated_at: 3.months.ago)
+    old_account2 = create(:account, updated_at: 1.year.ago)
+    account3 = create(:account, updated_at: 1.month.ago)
+
+    assert_equal [old_account1, old_account2], Account.not_recently_updated
+  end
+
   test 'sole_accounts and without_matches are chainable' do
     user1 = create(:user)
     account1 = create(:account, user: user1)

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -277,17 +277,17 @@ class AccountTest < ActiveSupport::TestCase
     assert_includes account.errors.messages[:battletag], "can't be blank"
   end
 
-  test 'deletes matches when deleted' do
+  test 'deletes season shares when deleted' do
     account = create(:account)
-    match1 = create(:match, account: account)
-    match2 = create(:match, account: account)
+    share1 = create(:season_share, account: account, season: seasons(:one).number)
+    share2 = create(:season_share, account: account, season: seasons(:two).number)
 
-    assert_difference 'Match.count', -2 do
+    assert_difference 'SeasonShare.count', -2 do
       account.reload.destroy
     end
 
-    refute Match.exists?(match1.id)
-    refute Match.exists?(match2.id)
+    refute SeasonShare.exists?(share1.id)
+    refute SeasonShare.exists?(share2.id)
   end
 
   test 'requires provider' do

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -8,6 +8,22 @@ class AccountTest < ActiveSupport::TestCase
     clear_enqueued_jobs
   end
 
+  test 'sole_accounts and without_matches are chainable' do
+    user1 = create(:user)
+    account1 = create(:account, user: user1)
+    create(:match, account: account1)
+
+    user2 = create(:user)
+    account2 = create(:account, user: user2)
+    account3 = create(:account, user: user2)
+    create(:match, account: account3)
+
+    user3 = create(:user)
+    account4 = create(:account, user: user3)
+
+    assert_equal [account4], Account.without_matches.sole_accounts
+  end
+
   test 'sole_accounts returns accounts that are the sole account for their user' do
     user1 = create(:user)
     account1 = create(:account, user: user1)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -161,17 +161,19 @@ class UserTest < ActiveSupport::TestCase
     refute Friend.exists?(friend2.id)
   end
 
-  test 'deletes OAuth accounts when deleted' do
+  test 'raises exception if has accounts when trying to destroy' do
     user = create(:user)
     account1 = create(:account, user: user)
     account2 = create(:account, user: user)
 
-    assert_difference 'Account.count', -2 do
-      user.destroy
+    assert_no_difference 'Account.count' do
+      assert_raises ActiveRecord::DeleteRestrictionError do
+        user.destroy
+      end
     end
 
-    refute Account.exists?(account1.id)
-    refute Account.exists?(account2.id)
+    assert Account.exists?(account1.id)
+    assert Account.exists?(account2.id)
   end
 
   test "friend_names returns empty list when season has no matches" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,6 +1,26 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
+  test 'total_by_account_count returns count of users having X accounts' do
+    user1 = create(:user)
+    create(:account, user: user1)
+
+    user2 = create(:user)
+    create(:account, user: user2)
+    create(:account, user: user2)
+
+    user3 = create(:user)
+    create(:account, user: user3)
+    create(:account, user: user3)
+
+    user4 = create(:user)
+    create(:account, user: user4)
+    create(:account, user: user4)
+
+    assert_equal 1, User.total_by_account_count(num_accounts: 1)
+    assert_equal 3, User.total_by_account_count(num_accounts: 2)
+  end
+
   test 'season_high returns highest rank from given season' do
     user = create(:user)
     account1 = create(:account, user: user)


### PR DESCRIPTION
This adds a section to the admin page that will let admins delete accounts that haven't been updated in 2 months, have no matches logged, and are the only accounts for their users (that is, the user hasn't linked any other accounts).

It also modifies accounts so that they will raise an exception if #destroy is called when they have matches. Similarly for users that have accounts.