### PR TITLE
Restrict maps based on the competitive season in which they were released

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -132,7 +132,7 @@ class MatchesController < ApplicationController
   end
 
   def get_maps
-    Rails.cache.fetch('maps') { Map.order(:name).select([:id, :name]) }
+    Rails.cache.fetch('maps:v2') { Map.order(:name) }
   end
 
   def get_heroes_by_role

--- a/app/helpers/matches_helper.rb
+++ b/app/helpers/matches_helper.rb
@@ -166,9 +166,12 @@ module MatchesHelper
     [['', '']] + valid_days.map { |name| [name.to_s.humanize, name] }
   end
 
-  def map_options(maps)
-    valid_maps = maps.map { |map| [map.name, map.id] }
-    [['Choose a map', '']] + valid_maps
+  def map_options(maps, selected_map_id:, season:)
+    valid_maps = maps.select do |map|
+      map.id == selected_map_id || map.available_in_season?(season)
+    end
+    map_options = valid_maps.map { |map| [map.name, map.id] }
+    [['Choose a map', '']] + map_options
   end
 
   def placement_count(matches)

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -4,9 +4,11 @@ class Map < ApplicationRecord
   VALID_MAP_TYPES = %w[assault escort hybrid control].freeze
 
   scope :order_by_name, ->{ order(:name) }
+  scope :available_in_season, ->(season) { where('first_season <= ?', season) }
 
   validates :name, presence: true, uniqueness: true
   validates :map_type, presence: true, inclusion: { in: VALID_MAP_TYPES }
+  validates :first_season, numericality: { greater_than: 0, only_integer: true }
 
   has_many :matches
 
@@ -25,5 +27,9 @@ class Map < ApplicationRecord
     return 'H. Lunar Colony' if name == 'Horizon Lunar Colony'
     return 'Anubis' if name == 'Temple of Anubis'
     name
+  end
+
+  def available_in_season?(season)
+    season >= first_season
   end
 end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -170,7 +170,7 @@ class Match < ApplicationRecord
 
   def self.map_win_percentages(season:)
     matches = in_season(season).with_map.with_result
-    maps = Map.select('name, id')
+    maps = Map.available_in_season(season).select('name, id')
     totals = Hash.new(0)
     wins = Hash.new(0)
     matches.each do |match|
@@ -226,7 +226,7 @@ class Match < ApplicationRecord
 
   def self.map_draw_percentages(season:)
     matches = in_season(season).with_map.with_result
-    maps = Map.select('name, id')
+    maps = Map.available_in_season(season).select('name, id')
     totals = Hash.new(0)
     draws = Hash.new(0)
     matches.each do |match|

--- a/app/views/matches/_map_field.html.erb
+++ b/app/views/matches/_map_field.html.erb
@@ -1,4 +1,4 @@
 <div class="form-group">
   <%= form.label :map_id, 'Map:', class: 'mr-2' %>
-  <%= form.select :map_id, options_for_select(map_options(maps), match.map_id), {}, { class: 'form-select' } %>
+  <%= form.select :map_id, options_for_select(map_options(maps, selected_map_id: match.map_id, season: match.season), match.map_id), {}, { class: 'form-select' } %>
 </div>

--- a/db/migrate/20180524031453_add_first_season_to_maps.rb
+++ b/db/migrate/20180524031453_add_first_season_to_maps.rb
@@ -1,0 +1,6 @@
+class AddFirstSeasonToMaps < ActiveRecord::Migration[5.1]
+  def change
+    add_column :maps, :first_season, :integer, null: false, default: 1
+    add_index :maps, :first_season
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180407152026) do
+ActiveRecord::Schema.define(version: 20180524031453) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,6 +57,8 @@ ActiveRecord::Schema.define(version: 20180407152026) do
     t.datetime "updated_at", null: false
     t.string "slug"
     t.string "color", limit: 16, default: "#ffffff", null: false
+    t.integer "first_season", default: 1, null: false
+    t.index ["first_season"], name: "index_maps_on_first_season"
     t.index ["name"], name: "index_maps_on_name", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,12 +26,22 @@ map_colors_by_name = {
   'Rialto' => '#87d0a4'
 }
 
+map_first_season_by_name = {
+  'Rialto' => 10,
+  'Blizzard World' => 9,
+  'Oasis' => 3,
+  'Horizon Lunar Colony' => 5,
+  'Junkertown' => 6,
+  'Eichenwalde' => 2
+}
+
 maps_by_type.each do |type, map_names|
   puts "Creating #{type} maps: #{map_names.to_sentence}"
   map_names.each do |name|
     map = Map.where(name: name).first_or_initialize
     map.map_type = type
     map.color = map_colors_by_name[name]
+    map.first_season = map_first_season_by_name[name] || 1
     map.save! if map.new_record? || map.changed?
   end
 end

--- a/test/models/map_test.rb
+++ b/test/models/map_test.rb
@@ -8,6 +8,20 @@ class MapTest < ActiveSupport::TestCase
     assert_includes map.errors.messages[:name], "can't be blank"
   end
 
+  test 'requires positive first_season' do
+    map = Map.new(first_season: -1)
+
+    refute_predicate map, :valid?
+    assert_includes map.errors.messages[:first_season], 'must be greater than 0'
+  end
+
+  test 'requires integer first_season' do
+    map = Map.new(first_season: 3.3)
+
+    refute_predicate map, :valid?
+    assert_includes map.errors.messages[:first_season], 'must be an integer'
+  end
+
   test 'requires unique name' do
     map1 = create(:map)
     map2 = Map.new(name: map1.name)

--- a/test/models/match_test.rb
+++ b/test/models/match_test.rb
@@ -17,7 +17,7 @@ class MatchTest < ActiveSupport::TestCase
     create(:match, day_of_week: :weekend, result: :win, season: 1)
     create(:match, day_of_week: :weekday, result: :win, season: 2)
 
-    assert_equal 50, Match.weekday_win_percent(season: 1)
+    assert_equal 50, Match.weekday_win_percent(season: 1, total_matches: 2)
   end
 
   test 'weekday_win_percent returns percentage of matches won on a weekday' do
@@ -27,7 +27,7 @@ class MatchTest < ActiveSupport::TestCase
     create(:match, day_of_week: :weekend, result: :win)
     create(:match, day_of_week: :weekday, result: :win)
 
-    assert_equal 100, Match.weekday_win_percent
+    assert_equal 100, Match.weekday_win_percent(total_matches: 2)
   end
 
   test 'weekend_win_percent looks only in specified season if given' do
@@ -37,7 +37,7 @@ class MatchTest < ActiveSupport::TestCase
     create(:match, day_of_week: :weekend, result: :win, season: 1)
     create(:match, day_of_week: :weekday, result: :win, season: 1)
 
-    assert_equal 50, Match.weekend_win_percent(season: 1)
+    assert_equal 50, Match.weekend_win_percent(season: 1, total_matches: 2)
   end
 
   test 'weekend_win_percent returns percentage of matches won on the weekend' do
@@ -47,7 +47,7 @@ class MatchTest < ActiveSupport::TestCase
     create(:match, day_of_week: :weekend, result: :win)
     create(:match, day_of_week: :weekday, result: :win)
 
-    assert_equal 33, Match.weekend_win_percent
+    assert_equal 33, Match.weekend_win_percent(total_matches: 3)
   end
 
   test 'weekends returns only weekend matches' do


### PR DESCRIPTION
Keeps Rialto from being marked as the map you played in a season prior to season 10 when it became available.