### PR TITLE
Just show group size for non-season owner

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -219,6 +219,10 @@ strong {
     margin-right: 16px !important;
   }
 
+  .mb-4-md {
+    margin-bottom: 24px !important;
+  }
+
   .ml-4-md {
     margin-left: 24px !important;
   }

--- a/app/controllers/trends_controller.rb
+++ b/app/controllers/trends_controller.rb
@@ -94,6 +94,7 @@ class TrendsController < ApplicationController
   end
 
   def all_accounts
+    @is_owner = signed_in? && match_source_user == current_user
     @matches = account_matches_in_season.
       includes(:account, :map, :prior_match).with_result.ordered_by_time
     Match.prefill_group_members(@matches, user: match_source_user)

--- a/app/controllers/trends_controller.rb
+++ b/app/controllers/trends_controller.rb
@@ -30,6 +30,7 @@ class TrendsController < ApplicationController
   end
 
   def all_seasons_accounts
+    @is_owner = signed_in? && match_source_user == current_user
     @active_seasons = current_user.active_seasons
     @matches = account_matches_in_season.
       includes(:prior_match, :map, :account).with_result.ordered_by_time

--- a/app/controllers/trends_controller.rb
+++ b/app/controllers/trends_controller.rb
@@ -62,6 +62,7 @@ class TrendsController < ApplicationController
   end
 
   def all_seasons
+    @is_owner = signed_in? && @account.user == current_user
     @active_seasons = @account.active_seasons
     @matches = account_matches_in_season.includes(:prior_match, :map).
       with_result.ordered_by_time

--- a/app/helpers/trends_helper.rb
+++ b/app/helpers/trends_helper.rb
@@ -59,13 +59,14 @@ module TrendsHelper
     end
   end
 
-  def show_sidebar?(matches)
-    show_group_charts_tab?(matches) || show_hero_charts_tab?(matches) ||
+  def show_sidebar?(matches, is_owner:)
+    show_group_charts_tab?(matches, is_owner: is_owner) ||
+      show_hero_charts_tab?(matches) ||
       show_time_charts_tab?(matches)
   end
 
-  def show_group_charts_tab?(matches)
-    show_group_member_chart?(matches)
+  def show_group_charts_tab?(matches, is_owner:)
+    is_owner && show_group_member_chart?(matches)
   end
 
   def show_hero_charts_tab?(matches)

--- a/app/views/matches/_match_history.html.erb
+++ b/app/views/matches/_match_history.html.erb
@@ -100,7 +100,7 @@
               <% if can_edit %>
                 <%= match.group_member_names.join(', ') %>
               <% else %>
-                <%= group_size_name(match.group_members.size) %>
+                <%= group_size_name(match.group_size) %>
               <% end %>
             </td>
           <% end %>

--- a/app/views/matches/_match_history.html.erb
+++ b/app/views/matches/_match_history.html.erb
@@ -97,7 +97,11 @@
           <% end %>
           <% if show_group_column %>
             <td class="match-cell hide-sm friends-cell">
-              <%= match.group_member_names.join(', ') %>
+              <% if can_edit %>
+                <%= match.group_member_names.join(', ') %>
+              <% else %>
+                <%= group_size_name(match.group_members.size) %>
+              <% end %>
             </td>
           <% end %>
           <% if show_thrower_leaver_column %>

--- a/app/views/season_shares/index.html.erb
+++ b/app/views/season_shares/index.html.erb
@@ -6,7 +6,7 @@
 
 <div class="d-flex-md flex-wrap">
   <% @accounts.each do |account| %>
-    <div class="Box p-3 mb-4-sm mr-4-md account-box">
+    <div class="Box p-3 mb-4-sm mr-4-md mb-4-md account-box">
       <h3 class="h3 mb-2 text-normal d-flex flex-items-center">
         <%= avatar_for(account, classes: 'mr-1') %>
         <%= account %>

--- a/app/views/trends/_sidebar.html.erb
+++ b/app/views/trends/_sidebar.html.erb
@@ -4,7 +4,7 @@
       General
     </a>
   </li>
-  <% if show_group_charts_tab?(matches) %>
+  <% if show_group_charts_tab?(matches, is_owner: is_owner) %>
     <li>
       <a href="#group-charts" class="filter-item js-tab" role="tab">
         Groups

--- a/app/views/trends/all_accounts.html.erb
+++ b/app/views/trends/all_accounts.html.erb
@@ -1,15 +1,18 @@
-<% content_for(:title, "All Accounts / Season #{@season} / Trends") %>
+<%
+  content_for(:title, "All Accounts / Season #{@season} / Trends")
+  show_sidebar = show_sidebar?(@matches, is_owner: @is_owner)
+%>
 
 <%= render partial: 'trends/top_nav', locals: { season: @season } %>
 
 <div class="clearfix">
-  <% if show_sidebar?(@matches) %>
+  <% if show_sidebar %>
     <div class="col-md-2 float-left">
       <%= render partial: 'trends/sidebar',
                  locals: { matches: @matches, season: @season } %>
     </div>
   <% end %>
-  <div<% if show_sidebar?(@matches) %> class="col-md-10 float-left"<% end %>>
+  <div<% if show_sidebar %> class="col-md-10 float-left"<% end %>>
     <div id="general-charts" class="js-tab-contents tab-contents">
       <div class="clearfix">
         <div class="col-md-6 float-md-left">

--- a/app/views/trends/all_seasons.html.erb
+++ b/app/views/trends/all_seasons.html.erb
@@ -1,15 +1,19 @@
-<% content_for(:title, "#{@account} / All Seasons / Trends") %>
+<%
+  content_for(:title, "#{@account} / All Seasons / Trends")
+  show_sidebar = show_sidebar?(@matches, is_owner: @is_owner)
+%>
 
 <%= render partial: 'trends/top_nav', locals: { account: @account } %>
 
 <div class="clearfix">
-  <% if show_sidebar?(@matches) %>
+  <% if show_sidebar %>
     <div class="col-md-2 float-left">
       <%= render partial: 'trends/sidebar',
-                 locals: { matches: @matches, account: @account } %>
+                 locals: { matches: @matches, account: @account,
+                           is_owner: @is_owner } %>
     </div>
   <% end %>
-  <div<% if show_sidebar?(@matches) %> class="col-md-10 float-left"<% end %>>
+  <div<% if show_sidebar %> class="col-md-10 float-left"<% end %>>
     <div id="general-charts" class="js-tab-contents tab-contents">
       <div class="clearfix">
         <div class="col-md-6 float-md-left">

--- a/app/views/trends/all_seasons_accounts.html.erb
+++ b/app/views/trends/all_seasons_accounts.html.erb
@@ -1,15 +1,18 @@
-<% content_for(:title, "All Seasons and Accounts / Trends") %>
+<%
+  content_for(:title, "All Seasons and Accounts / Trends")
+  show_sidebar = show_sidebar?(@matches, is_owner: @is_owner)
+%>
 
 <%= render partial: 'trends/top_nav' %>
 
 <div class="clearfix">
-  <% if show_sidebar?(@matches) %>
+  <% if show_sidebar %>
     <div class="col-md-2 float-left">
       <%= render partial: 'trends/sidebar',
-                 locals: { matches: @matches } %>
+                 locals: { matches: @matches, is_owner: @is_owner } %>
     </div>
   <% end %>
-  <div<% if show_sidebar?(@matches) %> class="col-md-10 float-left"<% end %>>
+  <div<% if show_sidebar %> class="col-md-10 float-left"<% end %>>
     <div id="general-charts" class="js-tab-contents tab-contents">
       <div class="clearfix mb-4">
         <div class="col-md-6 pr-4-md float-md-left">

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -34,10 +34,12 @@
         <%= render partial: 'trends/general_charts',
                    locals: { season: @season, matches: @matches } %>
       </div>
-      <div id="group-charts" class="js-tab-contents tab-contents d-none">
-        <%= render partial: 'trends/group_charts',
-                   locals: { season: @season, matches: @matches } %>
-      </div>
+      <% if show_group_charts_tab?(@matches, is_owner: @is_owner) %>
+        <div id="group-charts" class="js-tab-contents tab-contents d-none">
+          <%= render partial: 'trends/group_charts',
+                     locals: { season: @season, matches: @matches } %>
+        </div>
+      <% end %>
       <div id="hero-charts" class="js-tab-contents tab-contents d-none">
         <%= render partial: 'trends/hero_charts',
                    locals: { season: @season, matches: @matches } %>

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -1,16 +1,20 @@
-<% content_for(:title, "#{@account} / Season #{@season} / Trends") %>
+<%
+  content_for(:title, "#{@account} / Season #{@season} / Trends")
+  show_sidebar = show_sidebar?(@matches, is_owner: @is_owner)
+%>
 
 <%= render partial: 'trends/top_nav', locals: { season: @season, account: @account } %>
 
 <div class="clearfix">
-  <% if show_sidebar?(@matches) %>
+  <% if show_sidebar %>
     <div class="col-md-2 float-left">
       <%= render partial: 'trends/sidebar',
-                 locals: { matches: @matches, account: @account, season: @season } %>
+                 locals: { matches: @matches, account: @account, season: @season,
+                           is_owner: @is_owner } %>
     </div>
   <% end %>
 
-  <div<% if show_sidebar?(@matches) %> class="col-md-10 float-left"<% end %>>
+  <div<% if show_sidebar %> class="col-md-10 float-left"<% end %>>
     <% if @matches.empty? %>
       <div class="blankslate mb-4">
         <% if @season.future? %>

--- a/app/views/users/settings.html.erb
+++ b/app/views/users/settings.html.erb
@@ -8,7 +8,7 @@
   <%= settings_box(icon_class: 'ion-eye',
                    title: 'Manage match visibility',
                    url: season_shares_path,
-                   description: 'Change whether others can view your match history.') %>
+                   description: 'Change whether others can view your matches and season trends.') %>
 </div>
 
 <div class="d-flex-md flex-justify-between-md">


### PR DESCRIPTION
When a user shares their season, don't need to show friend names, they only matter to the person who logged the match. Just show "solo queue", "2-stack", etc. when viewing someone else's season. Don't show 'Groups' tab on trends page when viewing someone else's season.